### PR TITLE
Fix CSI initialization conflict

### DIFF
--- a/pkg/volume/csi/csi_plugin.go
+++ b/pkg/volume/csi/csi_plugin.go
@@ -238,21 +238,25 @@ func (p *csiPlugin) Init(host volume.VolumeHost) error {
 	}
 
 	// Initializing the label management channels
-	nim = nodeinfomanager.NewNodeInfoManager(host.GetNodeName(), host, migratedPlugins)
+	localNim := nodeinfomanager.NewNodeInfoManager(host.GetNodeName(), host, migratedPlugins)
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.CSINodeInfo) &&
 		utilfeature.DefaultFeatureGate.Enabled(features.CSIMigration) {
 		// This function prevents Kubelet from posting Ready status until CSINode
 		// is both installed and initialized
-		if err := initializeCSINode(host); err != nil {
+		if err := initializeCSINode(host, localNim); err != nil {
 			return errors.New(log("failed to initialize CSINode: %v", err))
 		}
+	}
+
+	if _, ok := host.(volume.KubeletVolumeHost); ok {
+		nim = localNim
 	}
 
 	return nil
 }
 
-func initializeCSINode(host volume.VolumeHost) error {
+func initializeCSINode(host volume.VolumeHost, nim nodeinfomanager.Interface) error {
 	kvh, ok := host.(volume.KubeletVolumeHost)
 	if !ok {
 		klog.V(4).Info("Cast from VolumeHost to KubeletVolumeHost failed. Skipping CSINode initialization, not running on kubelet")


### PR DESCRIPTION
CSI is used by both the kubelet and kube-controller-manager.  Both
components will initialize the csiPlugin with different VolumeHost
objects.  The csiPlugin will then assign a global variable for
the node info manager.  It is then possible that the kubelet gets
the credentials of the kube-controller-manager and that will cause
CSI to fail.

